### PR TITLE
Replace 'bars' with 'measures' consistently in UI and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Read our [Breakbeat Science](docs/breakbeat-science.md) guide to understand the 
    - Load custom audio with File > Open
    - Set slice points automatically with "Split by Transients" or manually with Alt+Click
    - Adjust the Onset Threshold slider to control automatic transient detection sensitivity
-   - Use the bar-based slicing for rhythmically perfect divisions
+   - Use the measure-based slicing for rhythmically perfect divisions
 
 3. **Selection and Trimming**:
    - Set a start marker with Shift+Click (blue)

--- a/config/strings.json
+++ b/config/strings.json
@@ -18,15 +18,15 @@
     "zoomIn": "Zoom In",
     "zoomOut": "Zoom Out",
     "cut": "Cut Selection",
-    "splitBars": "Split by Bars",
+    "splitMeasures": "Split by Measures",
     "splitTransients": "Split by Transients",
     "close": "Close"
   },
   "labels": {
-    "numBars": "Number of bars:",
+    "numMeasures": "Number of measures:",
     "tempo": "Tempo:",
     "onsetThreshold": "Onset Threshold:",
-    "barResolutions": ["4th notes", "8th notes", "16th notes"]
+    "measureResolutions": ["4th notes", "8th notes", "16th notes"]
   },
   "dialogs": {
     "exportDirectoryTitle": "Select Export Directory",

--- a/docs/breakbeat-science.md
+++ b/docs/breakbeat-science.md
@@ -8,10 +8,10 @@ RCY encodes these workflows natively — not as nostalgic artifacts, but as **li
 
 ---
 
-## 1. ⏱️ Split by Grid (Quantized Bars/Beats/16ths)
+## 1. ⏱️ Split by Grid (Quantized Measures/Beats/16ths)
 
 ### 💡 Idea
-Chop the loop by **time**, not transients. Use equal divisions (e.g. 16th notes across 1–4 bars).
+Chop the loop by **time**, not transients. Use equal divisions (e.g. 16th notes across 1–4 measures).
 
 ### 🧠 Why It Mattered
 - It made rhythmic displacement *easy* in samplers (S950, S1000, etc.)
@@ -23,8 +23,8 @@ Chop the loop by **time**, not transients. Use equal divisions (e.g. 16th notes 
 - **The Chemical Brothers**, **Fatboy Slim** — big beat architects who weaponized repetition and groove
 
 ### 🛠️ In RCY
-- Use "Split by Bars" and set subdivision to 16th, 8th, or 4th notes
-- No transient detection required — just a bar count and tempo
+- Use "Split by Measures" and set subdivision to 16th, 8th, or 4th notes
+- No transient detection required — just a measure count and tempo
 
 ---
 
@@ -87,7 +87,7 @@ RCY revives these three patterns not as nostalgia, but as:
 
 ## 🛠 Suggested RCY Workflow
 
-- Use **Split by Bars** when hunting for energy and surprise
+- Use **Split by Measures** when hunting for energy and surprise
 - Use **Manual Slicing** when chasing vibe
 - Use **Presets** when honoring lineage or borrowing taste
 

--- a/src/python/audio_processor.py
+++ b/src/python/audio_processor.py
@@ -78,17 +78,17 @@ class WavAudioProcessor:
         end_idx = int(end_time * self.sample_rate)
         return self.time[start_idx:end_idx], self.data[start_idx:end_idx]
 
-    def get_tempo(self, num_bars: int,
-                        beats_per_bar: int = 4) -> float:
-        total_beats = num_bars * beats_per_bar
+    def get_tempo(self, num_measures: int,
+                        beats_per_measure: int = 4) -> float:
+        total_beats = num_measures * beats_per_measure
         total_time_minutes = self.total_time / 60
         tempo = total_beats / total_time_minutes
         return tempo
 
-    def split_by_bars(self, num_bars, bar_resolution):
-        samples_per_bar = len(self.data) // num_bars
-        samples_per_slice = samples_per_bar // bar_resolution
-        self.segments = [i * samples_per_slice for i in range(1, num_bars * bar_resolution)]
+    def split_by_measures(self, num_measures, measure_resolution):
+        samples_per_measure = len(self.data) // num_measures
+        samples_per_slice = samples_per_measure // measure_resolution
+        self.segments = [i * samples_per_slice for i in range(1, num_measures * measure_resolution)]
         return self.segments
 
     def split_by_transients(self, threshold=0.2):

--- a/src/python/export_utils.py
+++ b/src/python/export_utils.py
@@ -25,12 +25,12 @@ class MIDIFileWithMetadata(MIDIFile):
 
 class ExportUtils:
     @staticmethod
-    def export_segments(model, tempo, num_bars, directory):
+    def export_segments(model, tempo, num_measures, directory):
         segments = model.get_segments()
         audio_data = model.data
         sample_rate = model.sample_rate
         total_duration = len(audio_data) / sample_rate
-        tempo = model.get_tempo(num_bars)
+        tempo = model.get_tempo(num_measures)
 
         print(f"Debug: Total duration: {total_duration} seconds")
         print(f"Debug: Tempo: {tempo} BPM")

--- a/src/python/main.py
+++ b/src/python/main.py
@@ -29,7 +29,7 @@ def main():
     controller.update_view()
     
     # Ensure tempo is calculated and displayed
-    controller.tempo = controller.model.get_tempo(controller.num_bars)
+    controller.tempo = controller.model.get_tempo(controller.num_measures)
     view.update_tempo(controller.tempo)
     
     view.show()

--- a/src/python/rcy_controller.py
+++ b/src/python/rcy_controller.py
@@ -10,15 +10,15 @@ class RcyController:
     def __init__(self, model):
         self.model = model
         self.visible_time = 10  # Initial visible time window
-        self.num_bars = 1
-        self.bar_resolution = 4
+        self.num_measures = 1
+        self.measure_resolution = 4
         self.tempo = 120
         self.threshold = 0.20
         self.view = None
 
     def set_view(self, view):
         self.view = view
-        self.view.bars_changed.connect(self.on_bars_changed)
+        self.view.measures_changed.connect(self.on_measures_changed)
         self.view.threshold_changed.connect(self.on_threshold_changed)
         self.view.remove_segment.connect(self.remove_segment)
         self.view.add_segment.connect(self.add_segment)
@@ -38,12 +38,12 @@ class RcyController:
     def export_segments(self, directory):
         return ExportUtils.export_segments(self.model,
                                            self.tempo,
-                                           self.num_bars,
+                                           self.num_measures,
                                            directory)
 
     def load_audio_file(self, filename):
         self.model.set_filename(filename)
-        self.tempo = self.model.get_tempo(self.num_bars)
+        self.tempo = self.model.get_tempo(self.num_measures)
         self.update_view()
         self.view.update_scroll_bar(self.visible_time, self.model.total_time)
         self.view.update_tempo(self.tempo)
@@ -61,14 +61,14 @@ class RcyController:
         try:
             self.model.load_preset(preset_id)
             
-            # Update number of bars if specified in the preset
+            # Update number of measures if specified in the preset
             if 'measures' in preset_info:
-                self.num_bars = preset_info['measures']
-                if hasattr(self.view, 'bars_input'):
-                    self.view.bars_input.setText(str(self.num_bars))
+                self.num_measures = preset_info['measures']
+                if hasattr(self.view, 'measures_input'):
+                    self.view.measures_input.setText(str(self.num_measures))
             
             # Update tempo
-            self.tempo = self.model.get_tempo(self.num_bars)
+            self.tempo = self.model.get_tempo(self.num_measures)
             
             # Update view
             self.update_view()
@@ -108,18 +108,18 @@ class RcyController:
     def get_tempo(self):
         return self.tempo
 
-    def on_bars_changed(self, num_bars):
-        self.num_bars = num_bars
-        self.tempo = self.model.get_tempo(self.num_bars)
+    def on_measures_changed(self, num_measures):
+        self.num_measures = num_measures
+        self.tempo = self.model.get_tempo(self.num_measures)
         self.view.update_tempo(self.tempo)
 
-    def set_bar_resolution(self, resolution):
-        self.bar_resolution = resolution
-        self.split_audio(method='bars', bar_resolution=resolution)
+    def set_measure_resolution(self, resolution):
+        self.measure_resolution = resolution
+        self.split_audio(method='measures', measure_resolution=resolution)
 
-    def split_audio(self, method='bars', bar_resolution=4):
-        if method == 'bars':
-            slices = self.model.split_by_bars(self.num_bars, bar_resolution)
+    def split_audio(self, method='measures', measure_resolution=4):
+        if method == 'measures':
+            slices = self.model.split_by_measures(self.num_measures, measure_resolution)
         elif method == 'transients':
             slices = self.model.split_by_transients(threshold=self.threshold)
         else:

--- a/src/python/rcy_view.py
+++ b/src/python/rcy_view.py
@@ -9,7 +9,7 @@ from matplotlib.patches import Polygon
 import numpy as np
 
 class RcyView(QMainWindow):
-    bars_changed = pyqtSignal(int)
+    measures_changed = pyqtSignal(int)
     threshold_changed = pyqtSignal(float)
     add_segment = pyqtSignal(float)
     remove_segment = pyqtSignal(float)
@@ -132,13 +132,13 @@ class RcyView(QMainWindow):
         info_layout = QHBoxLayout()
         slice_layout = QHBoxLayout()
 
-        ## Number of Bars Input
-        self.bars_label = QLabel(config.get_string("labels", "numBars"))
-        self.bars_input = QLineEdit("1")
-        self.bars_input.setValidator(QIntValidator(1, 1000))
-        self.bars_input.editingFinished.connect(self.on_bars_changed)
-        info_layout.addWidget(self.bars_label)
-        info_layout.addWidget(self.bars_input)
+        ## Number of Measures Input
+        self.measures_label = QLabel(config.get_string("labels", "numMeasures"))
+        self.measures_input = QLineEdit("1")
+        self.measures_input.setValidator(QIntValidator(1, 1000))
+        self.measures_input.editingFinished.connect(self.on_measures_changed)
+        info_layout.addWidget(self.measures_label)
+        info_layout.addWidget(self.measures_input)
 
         ## Tempo Display
         self.tempo_label = QLabel(config.get_string("labels", "tempo"))
@@ -153,21 +153,21 @@ class RcyView(QMainWindow):
         #info_layout.addWidget(self.load_button)
 
         ## add split buttons
-        self.split_bars_button = QPushButton(config.get_string("buttons", "splitBars"))
-        self.split_bars_button.clicked.connect(lambda: self.controller.split_audio('bars'))
+        self.split_measures_button = QPushButton(config.get_string("buttons", "splitMeasures"))
+        self.split_measures_button.clicked.connect(lambda: self.controller.split_audio('measures'))
 
         self.split_transients_button = QPushButton(config.get_string("buttons", "splitTransients"))
         self.split_transients_button.clicked.connect(lambda: self.controller.split_audio('transients'))
 
-        # Add bar resolution dropdown
-        self.bar_resolution_combo = QComboBox()
-        bar_resolutions = config.get_string("labels", "barResolutions")
-        self.bar_resolution_combo.addItems(bar_resolutions)
-        self.bar_resolution_combo.currentIndexChanged.connect(self.on_bar_resolution_changed)
+        # Add measure resolution dropdown
+        self.measure_resolution_combo = QComboBox()
+        measure_resolutions = config.get_string("labels", "measureResolutions")
+        self.measure_resolution_combo.addItems(measure_resolutions)
+        self.measure_resolution_combo.currentIndexChanged.connect(self.on_measure_resolution_changed)
         # add to layout
-        slice_layout.addWidget(self.split_bars_button)
+        slice_layout.addWidget(self.split_measures_button)
         slice_layout.addWidget(self.split_transients_button)
-        slice_layout.addWidget(self.bar_resolution_combo)
+        slice_layout.addWidget(self.measure_resolution_combo)
 
         # add to layout
         main_layout.addLayout(info_layout)
@@ -391,17 +391,17 @@ class RcyView(QMainWindow):
         self.controller.current_slices = slice_times
         print(f"Debugging: Updated current_slices in controller: {self.controller.current_slices}")
 
-    def on_bars_changed(self):
-        text = self.bars_input.text()
-        validator = self.bars_input.validator()
+    def on_measures_changed(self):
+        text = self.measures_input.text()
+        validator = self.measures_input.validator()
         state, _, _ = validator.validate(text, 0)
 
         if state == QValidator.State.Acceptable:
-            num_bars = int(text)
-            self.bars_changed.emit(num_bars)
+            num_measures = int(text)
+            self.measures_changed.emit(num_measures)
         else:
-            self.bars_input.setText(str(getattr(self.controller,
-                                                'num_bars', 1)))
+            self.measures_input.setText(str(getattr(self.controller,
+                                                'num_measures', 1)))
 
     def update_tempo(self, tempo):
         self.tempo_display.setText(f"{tempo:.2f} BPM")
@@ -769,9 +769,9 @@ class RcyView(QMainWindow):
                                  config.get_string("dialogs", "errorTitle"),
                                  config.get_string("dialogs", "errorLoadingFile"))
 
-    def on_bar_resolution_changed(self, index):
+    def on_measure_resolution_changed(self, index):
         resolutions = [4, 8, 16]
-        self.controller.set_bar_resolution(resolutions[index])
+        self.controller.set_measure_resolution(resolutions[index])
         
     def show_keyboard_shortcuts(self):
         """Show a dialog with keyboard shortcuts information"""


### PR DESCRIPTION
## Summary
This PR standardizes terminology throughout the codebase by replacing all instances of 'bars' with 'measures' to align with proper musical terminology.

## Changes
- Updated UI strings in strings.json (buttons, labels)
- Renamed variables, method names, and parameters in Python code
- Updated documentation in README.md and breakbeat-science.md
- Fixed function signatures and API calls 
- Maintained functionality while improving terminology consistency

## Test Plan
- Manually verified that the UI correctly displays 'measures' instead of 'bars'
- Tested that the application loads presets correctly
- Confirmed that all functionality (splitting, playback, export) works as before
- Verified that the tempo calculation still functions properly

Closes #42