### PR TITLE
Expand 'Split by Measures' to support all standard subdivisions

### DIFF
--- a/config/strings.json
+++ b/config/strings.json
@@ -26,7 +26,13 @@
     "numMeasures": "Number of measures:",
     "tempo": "Tempo:",
     "onsetThreshold": "Onset Threshold:",
-    "measureResolutions": ["4th notes", "8th notes", "16th notes"]
+    "measureResolutions": [
+      {"label": "Whole Note (1)", "value": 1},
+      {"label": "Half Note (2)", "value": 2},
+      {"label": "Quarter Note (4)", "value": 4},
+      {"label": "Eighth Note (8)", "value": 8},
+      {"label": "Sixteenth Note (16)", "value": 16}
+    ]
   },
   "dialogs": {
     "exportDirectoryTitle": "Select Export Directory",

--- a/src/python/rcy_controller.py
+++ b/src/python/rcy_controller.py
@@ -114,12 +114,14 @@ class RcyController:
         self.view.update_tempo(self.tempo)
 
     def set_measure_resolution(self, resolution):
+        """Set the measure resolution without automatically triggering a split"""
         self.measure_resolution = resolution
-        self.split_audio(method='measures', measure_resolution=resolution)
 
-    def split_audio(self, method='measures', measure_resolution=4):
+    def split_audio(self, method='measures', measure_resolution=None):
         if method == 'measures':
-            slices = self.model.split_by_measures(self.num_measures, measure_resolution)
+            # Use the provided resolution or fall back to the stored value
+            resolution = measure_resolution if measure_resolution is not None else self.measure_resolution
+            slices = self.model.split_by_measures(self.num_measures, resolution)
         elif method == 'transients':
             slices = self.model.split_by_transients(threshold=self.threshold)
         else:

--- a/src/python/rcy_view.py
+++ b/src/python/rcy_view.py
@@ -154,15 +154,23 @@ class RcyView(QMainWindow):
 
         ## add split buttons
         self.split_measures_button = QPushButton(config.get_string("buttons", "splitMeasures"))
-        self.split_measures_button.clicked.connect(lambda: self.controller.split_audio('measures'))
+        self.split_measures_button.clicked.connect(self.on_split_measures_clicked)
 
         self.split_transients_button = QPushButton(config.get_string("buttons", "splitTransients"))
         self.split_transients_button.clicked.connect(lambda: self.controller.split_audio('transients'))
 
         # Add measure resolution dropdown
         self.measure_resolution_combo = QComboBox()
-        measure_resolutions = config.get_string("labels", "measureResolutions")
-        self.measure_resolution_combo.addItems(measure_resolutions)
+        self.measure_resolutions = config.get_string("labels", "measureResolutions")
+        
+        # Add each resolution option to the dropdown
+        for resolution in self.measure_resolutions:
+            self.measure_resolution_combo.addItem(resolution["label"])
+        
+        # Set default selection to the Quarter Note (4) option
+        default_index = next((i for i, res in enumerate(self.measure_resolutions) if res["value"] == 4), 2)
+        self.measure_resolution_combo.setCurrentIndex(default_index)
+            
         self.measure_resolution_combo.currentIndexChanged.connect(self.on_measure_resolution_changed)
         # add to layout
         slice_layout.addWidget(self.split_measures_button)
@@ -770,8 +778,18 @@ class RcyView(QMainWindow):
                                  config.get_string("dialogs", "errorLoadingFile"))
 
     def on_measure_resolution_changed(self, index):
-        resolutions = [4, 8, 16]
-        self.controller.set_measure_resolution(resolutions[index])
+        # Get the resolution value from the configuration data
+        resolution_value = self.measure_resolutions[index]["value"]
+        self.controller.set_measure_resolution(resolution_value)
+        
+    def on_split_measures_clicked(self):
+        """Handle the Split by Measures button click by using the current dropdown selection"""
+        # Get the current resolution from the dropdown
+        current_index = self.measure_resolution_combo.currentIndex()
+        resolution_value = self.measure_resolutions[current_index]["value"]
+        
+        # Trigger the split with the current resolution
+        self.controller.split_audio(method='measures', measure_resolution=resolution_value)
         
     def show_keyboard_shortcuts(self):
         """Show a dialog with keyboard shortcuts information"""


### PR DESCRIPTION
## Summary
This PR enhances the 'Split by Measures' feature by adding support for a wider range of standard musical subdivisions, now including whole notes and half notes in addition to the existing quarter, eighth, and sixteenth note options.

## Changes
- Updated measureResolutions in strings.json to use structured objects with labels and values
- Made subdivision selection data-driven rather than hardcoded
- Added support for whole notes (1) and half notes (2)
- Fixed UI behavior:
  - Changing the dropdown now updates the stored resolution without triggering splits
  - The 'Split by Measures' button now uses the current dropdown selection
  - Default selection is still Quarter Note (4) for backward compatibility

## Test Plan
- Manually tested each subdivision option (1, 2, 4, 8, 16)
- Verified that changing the dropdown doesn't automatically re-slice
- Confirmed that clicking the button splits according to the selected subdivision
- Tested with various measures settings to ensure correct behavior

Closes #41