### PR TITLE
Fix segment marker modifier conflicts

### DIFF
--- a/src/python/rcy_view.py
+++ b/src/python/rcy_view.py
@@ -353,29 +353,34 @@ class RcyView(QMainWindow):
             self.dragging_marker = 'end'
             return
             
-        # Handle other clicks with modifiers
-        # On macOS, Command (Meta) key is sometimes triggered when Control is pressed
-        # Check for end marker setting first with more options
-        if (modifiers & Qt.KeyboardModifier.ControlModifier) or (modifiers & Qt.KeyboardModifier.MetaModifier):
-            # Check if it's actually the "Control" key using the event.modifiers string representation
-            print(f"Raw modifiers string: {str(modifiers)}")
-            # For macOS, we'll treat both Control and Command as candidates for end marker
-            # Add a special key specifically for end marker: 'e'
+        # Handle other clicks with modifiers - updated to fix conflicts
+        
+        # Check for Alt+Cmd (Meta) combination for removing segments
+        if (modifiers & Qt.KeyboardModifier.AltModifier) and (modifiers & Qt.KeyboardModifier.MetaModifier):
+            print(f"Alt+Cmd combination detected - removing segment at {event.xdata}")
+            self.remove_segment.emit(event.xdata)
+            return
+        
+        # Set end marker with Ctrl+Click (not Meta/Command)
+        if modifiers & Qt.KeyboardModifier.ControlModifier:
+            print(f"Control detected - setting end marker at {event.xdata}")
             self.set_end_marker(event.xdata)
-            print(f"Set end marker at {event.xdata}")
             return
             
-        # Other modifiers
+        # Set start marker with Shift+Click
         if modifiers & Qt.KeyboardModifier.ShiftModifier:
-            # Set start marker with Shift+Click
+            print(f"Shift detected - setting start marker at {event.xdata}")
             self.set_start_marker(event.xdata)
-            print(f"Set start marker at {event.xdata}")
-        elif modifiers & Qt.KeyboardModifier.AltModifier:
-            # Original Alt functionality
+            return
+            
+        # Add segment with Alt+Click
+        if modifiers & Qt.KeyboardModifier.AltModifier:
+            print(f"Alt detected - adding segment at {event.xdata}")
             self.add_segment.emit(event.xdata)
-        else:
-            # No modifiers
-            self.play_segment.emit(event.xdata)
+            return
+            
+        # No modifiers - play segment at click position
+        self.play_segment.emit(event.xdata)
             
     def is_near_marker(self, x, y, marker, marker_handle):
         """Check if coordinates are near the marker or its handle"""
@@ -989,7 +994,7 @@ class RcyView(QMainWindow):
         <h3>{config.get_string("shortcuts", "segmentsSection")}</h3>
         <ul>
             <li><b>Alt+Click</b>: {config.get_string("shortcuts", "addSegment")}</li>
-            <li><b>Meta+Click</b> (Command on macOS): {config.get_string("shortcuts", "removeSegment")}</li>
+            <li><b>Alt+Cmd+Click</b> (Alt+Meta on macOS): {config.get_string("shortcuts", "removeSegment")}</li>
         </ul>
         
         <h3>{config.get_string("shortcuts", "fileOperationsSection")}</h3>

--- a/tests/plans/segment_marker_shortcuts.md
+++ b/tests/plans/segment_marker_shortcuts.md
@@ -1,0 +1,65 @@
+# ✅ TEST PLAN: Segment Marker Keyboard Shortcuts (RCY)
+
+## 🧪 Environment
+
+- **OS**: macOS (tested on M1 or Intel)
+- **RCY version**: Latest commit with modifier support
+- **Audio file**: `amen_classic.wav` (stereo, 44100Hz)
+- **View**: Stereo waveform visible, no markers present at start
+
+---
+
+## 🎛 Modifier Behavior Tests
+
+### 1. Add Segment Marker
+- ⌨️ Action: `Alt + Click` at 25% along waveform
+- ✅ Expected: New vertical slice marker appears at clicked time on both L and R channels
+
+### 2. Remove Segment Marker
+- ⌨️ Action: `Alt + Cmd + Click` on existing marker
+- ✅ Expected: That marker is removed cleanly
+- ❌ No new markers created
+
+### 3. Set Start Marker
+- ⌨️ Action: `Shift + Click` at beginning of waveform
+- ✅ Expected: Green start marker appears
+
+### 4. Set End Marker
+- ⌨️ Action: `Ctrl + Click` near end of waveform
+- ✅ Expected: Red end marker appears
+
+---
+
+## 🔁 Combination Tests
+
+### 5. Add Two Segments + Set Range
+- Add two segment markers
+- Set start (`Shift + Click`) before 1st
+- Set end (`Ctrl + Click`) after 2nd
+- ✅ Expected: Start and end markers do not interfere with segment markers
+
+### 6. Remove Segment Inside Start/End Range
+- Add a few segments
+- Define a start/end range
+- Remove a segment inside the range
+- ✅ Expected: Only the segment is removed, range markers remain
+
+---
+
+## 🧼 Edge Cases
+
+### 7. Modifier Conflict Handling
+- ⌨️ Action: `Ctrl + Alt + Click`
+- ✅ Expected: No action OR a single defined behavior (log if ambiguous)
+
+### 8. Meta + Click Alone
+- ⌨️ Action: `Cmd + Click` (no Alt)
+- ✅ Expected: No action — does **not** remove segments (reserved for `Alt + Cmd` only)
+
+---
+
+## 📓 Notes
+
+- Repeat all tests with stereo files and mono files
+- Confirm segment visuals are updated in both channels
+- Validate marker removal logs if debug output is enabled


### PR DESCRIPTION
- Resolve shortcut conflicts between marker setting and segment creation/deletion
- Implement clear modifier hierarchy: Alt+Click adds segments, Alt+Cmd+Click removes segments
- Update keyboard shortcuts documentation to reflect new mapping
- Add comprehensive test plan in tests/plans/segment_marker_shortcuts.md
- Note: Full test plan execution recommended before finalizing

Closes #issue (replace with actual issue number)

🤖 Generated with [Claude Code](https://claude.ai/code)