### PR TITLE
Fix preset measure count initialization

### DIFF
--- a/src/python/main.py
+++ b/src/python/main.py
@@ -17,9 +17,23 @@ def main():
     try:
         # Create model with default preset 'amen_classic'
         model = WavAudioProcessor(preset_id='amen_classic')
+        
+        # Get preset info to initialize controller with correct measure count
+        preset_info = config.get_preset_info('amen_classic')
+        initial_measures = preset_info.get('measures', 1) if preset_info else 1
+        print(f"Initializing with preset amen_classic, measures={initial_measures}")
+        
+        # Create controller with correct initial measures
         controller = RcyController(model)
+        controller.num_measures = initial_measures  # Set before view creation
+        
+        # Create and connect view
         view = RcyView(controller)
         controller.set_view(view)
+        
+        # Ensure view has correct number of measures
+        if hasattr(view, 'measures_input'):
+            view.measures_input.setText(str(initial_measures))
     except Exception as e:
         app = QApplication(sys.argv)
         QMessageBox.critical(None, "Error", f"Failed to initialize application: {e}")
@@ -28,9 +42,10 @@ def main():
     # Initial update
     controller.update_view()
     
-    # Ensure tempo is calculated and displayed
+    # Ensure tempo is calculated and displayed with correct measure count
     controller.tempo = controller.model.get_tempo(controller.num_measures)
     view.update_tempo(controller.tempo)
+    print(f"Initial tempo: {controller.tempo:.2f} BPM based on {controller.num_measures} measures")
     
     view.show()
     sys.exit(app.exec())

--- a/src/python/rcy_controller.py
+++ b/src/python/rcy_controller.py
@@ -62,13 +62,25 @@ class RcyController:
             self.model.load_preset(preset_id)
             
             # Update number of measures if specified in the preset
-            if 'measures' in preset_info:
-                self.num_measures = preset_info['measures']
+            measures = preset_info.get('measures', 1)
+            if measures != self.num_measures:
+                # Only update if different to avoid unnecessary recalculations
+                self.num_measures = measures
+                print(f"Preset '{preset_id}' specifies {self.num_measures} measures")
+                
+                # Update the UI
                 if hasattr(self.view, 'measures_input'):
+                    # Temporarily block signals to avoid recursive updates
+                    old_state = self.view.measures_input.blockSignals(True)
                     self.view.measures_input.setText(str(self.num_measures))
+                    self.view.measures_input.blockSignals(old_state)
+                    print(f"Updated measures input to {self.num_measures}")
+            else:
+                print(f"Preset '{preset_id}' has same measure count ({measures}), no update needed")
             
-            # Update tempo
+            # Update tempo - This will now be calculated with the correct measure count
             self.tempo = self.model.get_tempo(self.num_measures)
+            print(f"Tempo: {self.tempo:.2f} BPM based on {self.num_measures} measures")
             
             # Update view
             self.update_view()


### PR DESCRIPTION
- Add proper handling of preset 'measures' metadata at startup
- Fix initialization sequence to set correct measure count before UI creation
- Update tempo calculation to use the correct measure count from presets
- Improve preset loading to handle measure count changes properly
- Fix issue #49 where amen_classic displayed incorrect tempo (34 BPM instead of 137 BPM)

🤖 Generated with [Claude Code](https://claude.ai/code)