### PR TITLE
Add playback tempo adjustment feature

### DIFF
--- a/CLAUDE_INIT.md
+++ b/CLAUDE_INIT.md
@@ -1,0 +1,57 @@
+# 🧭 RCY Coding Standards & Session Initialization Guidance
+
+This document outlines best practices and session setup expectations for contributing to the RCY codebase. It is primarily written for Claude (and other code agents) to follow during development, review, and refactoring tasks. It can also be used by human contributors to ensure consistency and clarity in the codebase.
+
+---
+
+## 📦 Project Structure
+
+RCY uses a modular directory layout with absolute imports and explicit runtime configuration.
+
+- All source code lives under: `src/python/`
+- All configuration lives under: `config/`
+- Tests are under: `tests/`
+- RCY expects `PYTHONPATH` to be set to the `src` directory when running any scripts or applications.
+
+---
+
+## ✅ Import Hygiene
+
+- All `import` statements must appear at the **top of the file**, not inside functions or conditional blocks.
+- **Do not modify `sys.path`** dynamically inside application files.
+- Assume the developer has set `PYTHONPATH=rcy/src` (or equivalent) before running any scripts. Use absolute imports based on this setup.
+- Do not add fallback import paths or multi-level resolution logic.
+- Example of correct imports:
+  ```python
+  from config_manager import config
+  from audio_processor import WavAudioProcessor
+  ```
+
+---
+
+## 🔄 Configuration Management
+
+- Configuration files are stored in the `config/` directory in JSON format
+- Use the `config_manager.py` module to access configuration values
+- Avoid hardcoding configuration values in the application code
+- Provide sensible defaults for all configuration parameters
+
+---
+
+## 🧪 Testing Practices
+
+- All tests should be placed in the `tests/` directory
+- When writing tests, ensure PYTHONPATH is correctly set to include the src directory
+- Mock external dependencies when appropriate
+- Include tests for new features and bug fixes
+- Run tests before submitting pull requests
+
+---
+
+## 🚀 Development Workflow
+
+- Create feature branches from main for new work
+- Follow the git commit message conventions
+- Use pull requests for code review
+- Ensure tests pass before merging
+- Update documentation when changing functionality

--- a/config/audio.json
+++ b/config/audio.json
@@ -15,5 +15,9 @@
     "postMax": 1,
     "deltaFactor": 0.1
   },
+  "playbackTempo": {
+    "enabled": false,
+    "targetBpm": 120
+  },
   "backend": "pyqtgraph"
 }

--- a/src/python/audio_processor.py
+++ b/src/python/audio_processor.py
@@ -22,12 +22,31 @@ class WavAudioProcessor:
         self.is_stereo = False
         self.channels = 1
         
+        # Initialize playback tempo settings
+        self._init_playback_tempo()
+        
         # Try to load the specified preset
         try:
             self.load_preset(preset_id)
         except Exception as e:
             print(f"ERROR: Failed to load preset '{preset_id}': {e}")
             sys.exit(1)
+    
+    def _init_playback_tempo(self):
+        """Initialize playback tempo settings from config"""
+        # Get playback tempo config with defaults
+        pt_config = config.get_value_from_json_file("audio.json", "playbackTempo", {})
+        
+        # Read settings with defaults
+        self.playback_tempo_enabled = pt_config.get("enabled", False)
+        self.target_bpm = int(pt_config.get("targetBpm", 120))
+        
+        # Source BPM is calculated from audio duration and measures
+        # Will be set properly after loading preset
+        self.source_bpm = 120.0  # Default value
+        
+        print(f"Playback tempo initialized: {self.playback_tempo_enabled}, "
+              f"target={self.target_bpm} BPM")
 
     def load_preset(self, preset_id):
         """Load an audio preset by its ID"""
@@ -82,6 +101,12 @@ class WavAudioProcessor:
             # Create time array based on the actual data length
             self.time = np.linspace(0, self.total_time, len(self.data_left))
             self.segments = []
+            
+            # Calculate source BPM based on the loaded audio file
+            measures = 4  # Default
+            if self.preset_info and 'measures' in self.preset_info:
+                measures = self.preset_info.get('measures')
+            self.calculate_source_bpm(measures=measures)
         except Exception as e:
             print(f"Error loading audio file {filename}: {e}")
             raise
@@ -258,16 +283,30 @@ class WavAudioProcessor:
         
         print(f"### Segment created with shape: {segment.shape}")
         
+        # Get the sample rate to use for playback (adjusted or original)
+        playback_sample_rate = self.sample_rate
+        if self.playback_tempo_enabled:
+            playback_sample_rate = self.get_adjusted_sample_rate()
+            print(f"### Using tempo-adjusted sample rate: {playback_sample_rate} Hz")
+        
         # Define the playback function for threading
         def play_audio():
             try:
                 print(f"### Starting playback thread for segment {start_time:.2f}s to {end_time:.2f}s")
+                if self.playback_tempo_enabled:
+                    ratio = self.get_playback_ratio()
+                    print(f"### Tempo adjustment active: {ratio:.2f}x ({self.source_bpm:.1f} → {self.target_bpm} BPM)")
+                    
                 self.is_playing = True
-                sd.play(segment, self.sample_rate)
+                
+                # Use the adjusted sample rate
+                sd.play(segment, playback_sample_rate)
                 sd.wait()  # This blocks until playback is complete
                 print("### Playback complete")
             except Exception as e:
                 print(f"### ERROR during playback: {e}")
+                import traceback
+                traceback.print_exc()
             finally:
                 self.is_playing = False
                 # Notify that playback has completed
@@ -297,6 +336,92 @@ class WavAudioProcessor:
 
     def get_sample_at_time(self, time):
         return int(time * self.sample_rate)
+    
+    def calculate_source_bpm(self, measures=None):
+        """Calculate source BPM based on audio duration and measure count
+        
+        Formula: Source BPM = (60 × measures) / duration
+        """
+        if not hasattr(self, 'total_time') or self.total_time <= 0:
+            print("Warning: Cannot calculate source BPM, invalid duration")
+            return 120.0  # Default fallback
+            
+        # Use provided measures or get from preset info
+        if measures is None:
+            if self.preset_info and 'measures' in self.preset_info:
+                measures = self.preset_info.get('measures', 4)
+            else:
+                measures = 4  # Default if not specified
+                
+        # Ensure positive value
+        if measures <= 0:
+            measures = 4
+            
+        # Calculate BPM
+        source_bpm = (60.0 * measures) / self.total_time
+        
+        # Store the calculated value
+        self.source_bpm = source_bpm
+        
+        print(f"Calculated source BPM: {source_bpm:.2f} based on {measures} measures and {self.total_time:.2f}s duration")
+        return source_bpm
+    
+    def get_playback_ratio(self):
+        """Calculate the playback ratio for tempo adjustment
+        
+        Formula: playbackRatio = targetBPM / sourceBPM
+        """
+        if not self.playback_tempo_enabled:
+            return 1.0  # No adjustment
+            
+        if not hasattr(self, 'source_bpm') or self.source_bpm <= 0:
+            # Recalculate if needed
+            self.calculate_source_bpm()
+            
+        if self.source_bpm <= 0:
+            return 1.0  # Safety check
+            
+        # Calculate the ratio
+        ratio = self.target_bpm / self.source_bpm
+        
+        print(f"Playback ratio: {ratio:.2f} (target: {self.target_bpm} BPM / source: {self.source_bpm:.2f} BPM)")
+        return ratio
+    
+    def get_adjusted_sample_rate(self):
+        """Get the sample rate adjusted for tempo change"""
+        if not self.playback_tempo_enabled:
+            return self.sample_rate
+            
+        # Calculate the playback ratio
+        ratio = self.get_playback_ratio()
+        
+        # Apply ratio to sample rate
+        adjusted_rate = int(self.sample_rate * ratio)
+        
+        print(f"Adjusted sample rate: {adjusted_rate} Hz (original: {self.sample_rate} Hz, ratio: {ratio:.2f})")
+        return adjusted_rate
+    
+    def set_playback_tempo(self, enabled, target_bpm=None):
+        """Configure playback tempo settings
+        
+        Args:
+            enabled (bool): Whether tempo adjustment is enabled
+            target_bpm (int, optional): Target tempo in BPM
+        """
+        self.playback_tempo_enabled = enabled
+        
+        if target_bpm is not None:
+            self.target_bpm = int(target_bpm)
+            
+        # Ensure source BPM is calculated
+        if not hasattr(self, 'source_bpm') or self.source_bpm <= 0:
+            self.calculate_source_bpm()
+            
+        print(f"Playback tempo updated: {self.playback_tempo_enabled}, "
+              f"target={self.target_bpm} BPM, source={self.source_bpm:.2f} BPM")
+        
+        # Return the new playback ratio for convenience
+        return self.get_playback_ratio()
         
     def cut_audio(self, start_sample, end_sample):
         """Trim audio to the region between start_sample and end_sample"""

--- a/src/python/audio_processor.py
+++ b/src/python/audio_processor.py
@@ -103,9 +103,7 @@ class WavAudioProcessor:
             self.segments = []
             
             # Calculate source BPM based on the loaded audio file
-            measures = 4  # Default
-            if self.preset_info and 'measures' in self.preset_info:
-                measures = self.preset_info.get('measures')
+            measures = None  # Use the value from preset_info
             self.calculate_source_bpm(measures=measures)
         except Exception as e:
             print(f"Error loading audio file {filename}: {e}")
@@ -340,7 +338,8 @@ class WavAudioProcessor:
     def calculate_source_bpm(self, measures=None):
         """Calculate source BPM based on audio duration and measure count
         
-        Formula: Source BPM = (60 × measures) / duration
+        Formula: Source BPM = (60 × beats) / duration
+        Where beats = measures × 4 (assuming 4/4 time signature)
         """
         if not hasattr(self, 'total_time') or self.total_time <= 0:
             print("Warning: Cannot calculate source BPM, invalid duration")
@@ -357,13 +356,19 @@ class WavAudioProcessor:
         if measures <= 0:
             measures = 4
             
-        # Calculate BPM
-        source_bpm = (60.0 * measures) / self.total_time
+        # Get beats per measure from config (default to 4/4 time signature)
+        beats_per_measure = 4  # Standard 4/4 time for breakbeats
+        
+        # Calculate total beats in the audio file
+        total_beats = measures * beats_per_measure
+        
+        # Calculate BPM based on total beats
+        source_bpm = (60.0 * total_beats) / self.total_time
         
         # Store the calculated value
         self.source_bpm = source_bpm
         
-        print(f"Calculated source BPM: {source_bpm:.2f} based on {measures} measures and {self.total_time:.2f}s duration")
+        print(f"Calculated source BPM: {source_bpm:.2f} based on {measures} measures × {beats_per_measure} beats = {total_beats} beats over {self.total_time:.2f}s duration")
         return source_bpm
     
     def get_playback_ratio(self):

--- a/src/python/rcy_view.py
+++ b/src/python/rcy_view.py
@@ -1,5 +1,5 @@
-from PyQt6.QtWidgets import QApplication, QLabel, QLineEdit, QComboBox, QMessageBox, QMainWindow, QFileDialog, QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QScrollBar, QSlider, QDialog, QTextBrowser
-from PyQt6.QtGui import QAction, QValidator, QIntValidator, QFont
+from PyQt6.QtWidgets import QApplication, QLabel, QLineEdit, QComboBox, QMessageBox, QMainWindow, QFileDialog, QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QScrollBar, QSlider, QDialog, QTextBrowser, QInputDialog, QCheckBox
+from PyQt6.QtGui import QAction, QActionGroup, QValidator, QIntValidator, QFont
 from PyQt6.QtCore import Qt, pyqtSignal, QSize
 from config_manager import config
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas

--- a/src/python/rcy_view.py
+++ b/src/python/rcy_view.py
@@ -66,6 +66,106 @@ class RcyView(QMainWindow):
                 self.toggle_playback()
                 return True
         return super().eventFilter(obj, event)
+        
+    def toggle_playback_tempo(self, enabled):
+        """Toggle playback tempo adjustment on/off
+        
+        Args:
+            enabled (bool): Whether playback tempo adjustment is enabled
+        """
+        print(f"Toggling playback tempo adjustment: {enabled}")
+        
+        # Update menu action if it exists
+        if hasattr(self, 'playback_tempo_action'):
+            self.playback_tempo_action.setChecked(enabled)
+        
+        # Update checkbox if it exists
+        if hasattr(self, 'playback_tempo_checkbox'):
+            self.playback_tempo_checkbox.setChecked(enabled)
+        
+        # Get the current target BPM from the dropdown
+        target_bpm = None
+        if hasattr(self, 'playback_tempo_combo'):
+            current_index = self.playback_tempo_combo.currentIndex()
+            if current_index >= 0:
+                target_bpm = self.playback_tempo_combo.itemData(current_index)
+        
+        # Update controller
+        if hasattr(self.controller, 'set_playback_tempo'):
+            self.controller.set_playback_tempo(enabled, target_bpm)
+    
+    def set_target_bpm(self, bpm):
+        """Set the target BPM for playback tempo adjustment
+        
+        Args:
+            bpm (int): Target BPM value
+        """
+        print(f"Setting target BPM to {bpm}")
+        
+        # Update dropdown if it exists
+        if hasattr(self, 'playback_tempo_combo'):
+            # Find the index for this BPM
+            for i in range(self.playback_tempo_combo.count()):
+                if self.playback_tempo_combo.itemData(i) == bpm:
+                    self.playback_tempo_combo.setCurrentIndex(i)
+                    break
+        
+        # Get current enabled state from checkbox
+        enabled = False
+        if hasattr(self, 'playback_tempo_checkbox'):
+            enabled = self.playback_tempo_checkbox.isChecked()
+        
+        # Update controller
+        if hasattr(self.controller, 'set_playback_tempo'):
+            self.controller.set_playback_tempo(enabled, bpm)
+    
+    def on_playback_tempo_changed(self, index):
+        """Handle changes to the playback tempo dropdown
+        
+        Args:
+            index (int): Index of the selected item
+        """
+        if index < 0:
+            return
+            
+        # Get the selected BPM
+        bpm = self.playback_tempo_combo.itemData(index)
+        print(f"Playback tempo changed to {bpm} BPM")
+        
+        # Get current enabled state
+        enabled = self.playback_tempo_checkbox.isChecked()
+        
+        # Update controller
+        if hasattr(self.controller, 'set_playback_tempo'):
+            self.controller.set_playback_tempo(enabled, bpm)
+    
+    def update_playback_tempo_display(self, enabled, source_bpm, target_bpm, ratio):
+        """Update the playback tempo UI display
+        
+        Args:
+            enabled (bool): Whether playback tempo adjustment is enabled
+            source_bpm (float): Source tempo in BPM
+            target_bpm (int): Target tempo in BPM
+            ratio (float): The playback ratio
+        """
+        # Update checkbox
+        if hasattr(self, 'playback_tempo_checkbox'):
+            self.playback_tempo_checkbox.setChecked(enabled)
+        
+        # Update source BPM display
+        if hasattr(self, 'source_bpm_display'):
+            self.source_bpm_display.setText(f"{source_bpm:.1f}")
+        
+        # Update dropdown to show the target BPM
+        if hasattr(self, 'playback_tempo_combo'):
+            for i in range(self.playback_tempo_combo.count()):
+                if self.playback_tempo_combo.itemData(i) == target_bpm:
+                    self.playback_tempo_combo.setCurrentIndex(i)
+                    break
+        
+        # Update menu action
+        if hasattr(self, 'playback_tempo_action'):
+            self.playback_tempo_action.setChecked(enabled)
 
     def create_menu_bar(self):
         menubar = self.menuBar()
@@ -95,6 +195,28 @@ class RcyView(QMainWindow):
         save_as_action = QAction(config.get_string("menus", "saveAs"), self)
         save_as_action.triggered.connect(self.save_as)
         file_menu.addAction(save_as_action)
+        
+        # Options menu
+        options_menu = menubar.addMenu("Options")
+        
+        # Playback Tempo submenu
+        playback_tempo_menu = options_menu.addMenu("Playback Tempo")
+        
+        # Enable/disable playback tempo adjustment
+        self.playback_tempo_action = QAction("Enable Tempo Adjustment", self)
+        self.playback_tempo_action.setCheckable(True)
+        self.playback_tempo_action.triggered.connect(self.toggle_playback_tempo)
+        playback_tempo_menu.addAction(self.playback_tempo_action)
+        
+        # Add separator
+        playback_tempo_menu.addSeparator()
+        
+        # Add common BPM choices
+        common_bpms = [80, 90, 100, 110, 120, 130, 140, 160, 170, 180]
+        for bpm in common_bpms:
+            bpm_action = QAction(f"{bpm} BPM", self)
+            bpm_action.triggered.connect(lambda checked, bpm=bpm: self.set_target_bpm(bpm))
+            playback_tempo_menu.addAction(bpm_action)
         
         # Help menu
         help_menu = menubar.addMenu(config.get_string("menus", "help"))
@@ -165,6 +287,35 @@ class RcyView(QMainWindow):
         self.tempo_display.setReadOnly(True)
         info_layout.addWidget(self.tempo_label)
         info_layout.addWidget(self.tempo_display)
+        
+        ## Playback Tempo Controls
+        # Create a horizontal layout for playback tempo
+        playback_tempo_layout = QHBoxLayout()
+        
+        # Create checkbox for enabling/disabling
+        self.playback_tempo_checkbox = QCheckBox("Tempo Adjust:")
+        self.playback_tempo_checkbox.setChecked(False)
+        self.playback_tempo_checkbox.toggled.connect(self.toggle_playback_tempo)
+        playback_tempo_layout.addWidget(self.playback_tempo_checkbox)
+        
+        # Create dropdown for target BPM
+        self.playback_tempo_combo = QComboBox()
+        common_bpms = [80, 90, 100, 110, 120, 130, 140, 160, 170, 180]
+        for bpm in common_bpms:
+            self.playback_tempo_combo.addItem(f"{bpm} BPM", bpm)
+        self.playback_tempo_combo.currentIndexChanged.connect(self.on_playback_tempo_changed)
+        playback_tempo_layout.addWidget(self.playback_tempo_combo)
+        
+        # Source BPM display
+        self.source_bpm_label = QLabel("Source:")
+        self.source_bpm_display = QLineEdit("0.0")
+        self.source_bpm_display.setReadOnly(True)
+        self.source_bpm_display.setFixedWidth(60)
+        playback_tempo_layout.addWidget(self.source_bpm_label)
+        playback_tempo_layout.addWidget(self.source_bpm_display)
+        
+        # Add the playback tempo layout to the info layout
+        info_layout.addLayout(playback_tempo_layout)
 
         ## Load Button
         #self.load_button = QPushButton("Load Audio")


### PR DESCRIPTION
## Summary
- Adds playback tempo adjustment feature that modifies sample rate for playback
- Implements UI controls with toggle, BPM selection, and display
- Calculates source BPM based on preset metadata (measures and duration)
- Adds sample rate adjustment for playback only (not export)

## Test plan
- Test with different presets (think_break, amen_classic, apache_break)
- Verify BPM calculation works for different measure values (1, 2, 4)
- Check that sample rate adjustment correctly speeds up or slows down audio
- Verify UI updates reflect correct source BPM and ratio

🤖 Generated with [Claude Code](https://claude.ai/code)