### PR TITLE
Fix Cut button functionality by using correct method name

### DIFF
--- a/src/python/rcy_view.py
+++ b/src/python/rcy_view.py
@@ -796,7 +796,7 @@ class RcyView(QMainWindow):
                                     QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
         
         # Remove highlight
-        self.waveform_view.clear_segment_highlight()
+        self.waveform_view.clear_active_segment_highlight()
                                     
         if reply == QMessageBox.StandardButton.Yes:
             # Emit the signal to request cutting


### PR DESCRIPTION
Fixes Issue #82. Changed clear_segment_highlight() to clear_active_segment_highlight() to match the actual method name in PyQtGraphWaveformView after migration.

🤖 Generated with [Claude Code](https://claude.ai/code)