### PR TITLE
Remove excessive debug code in waveform_view.py

### DIFF
--- a/src/python/waveform_view.py
+++ b/src/python/waveform_view.py
@@ -217,16 +217,13 @@ class PyQtGraphWaveformView(BaseWaveformView):
         """Create or update rectangular marker handle with a fixed pixel size"""
         # Make sure we have valid time data
         if self.time_data is None:
-            print(f"DEBUG: Cannot update {marker_type} marker handle - time_data is None")
             return
             
         # Fix for TypeError: object of type 'NoneType' has no len()
         try:
             if len(self.time_data) == 0:
-                print(f"DEBUG: Cannot update {marker_type} marker handle - time_data is empty")
                 return
         except TypeError:
-            print(f"DEBUG: TypeError in _update_marker_handle - time_data has no len()")
             return
         
         # Get marker reference
@@ -239,16 +236,13 @@ class PyQtGraphWaveformView(BaseWaveformView):
             
         # Ensure marker exists
         if marker is None:
-            print(f"DEBUG: Cannot update {marker_type} marker handle - marker is None")
             return
             
         try:
             position = marker.value()
             if position is None:
-                print(f"DEBUG: Cannot update {marker_type} marker handle - position is None")
                 return
         except Exception as e:
-            print(f"DEBUG: Error getting marker position: {e}")
             return
         
         # Get valid data range
@@ -257,7 +251,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         
         # Guard clause: Don't draw handles for markers outside data range
         if position < min_pos or position > max_pos:
-            print(f"DEBUG: Not drawing {marker_type} marker handle - position {position} is outside valid range [{min_pos}, {max_pos}]")
             
             # Remove existing handle if there is one
             handle_key = f"{marker_type}_handle"
@@ -270,7 +263,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         
         # Ensure active plot exists
         if self.active_plot is None:
-            print(f"DEBUG: Cannot update {marker_type} marker handle - active_plot is None")
             return
             
         
@@ -284,7 +276,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         # Get the view box for coordinate transformations
         view_box = self.active_plot.getViewBox()
         if view_box is None:
-            print(f"DEBUG: Cannot update {marker_type} marker handle - viewBox is None")
             return
         
         # Get UI configuration for marker size in pixels
@@ -298,7 +289,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
             x_min, x_max = x_range
             y_min, y_max = y_range
         except Exception as e:
-            print(f"DEBUG: Error getting view range: {e}")
             return
         
         # Calculate size in data units based on view range
@@ -307,7 +297,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         
         # Defensive check for zero values
         if view_width <= 0 or view_height <= 0:
-            print(f"DEBUG: Invalid view dimensions: width={view_width}, height={view_height}")
             return
             
         # Calculate the data units per pixel
@@ -341,7 +330,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
             pen=pg.mkPen(None)  # No border
         )
         
-        print(f"DEBUG: Created {marker_type} marker handle at position {position}")
         
         # Add to plot and store reference
         self.active_plot.addItem(handle)
@@ -481,41 +469,30 @@ class PyQtGraphWaveformView(BaseWaveformView):
         try:
             old_max_pos = self.time_data[-1] if self.time_data is not None and len(self.time_data) > 0 else None
         except TypeError:
-            print(f"DEBUG: TypeError in update_plot when accessing old_max_pos")
             old_max_pos = None
         old_total_time = getattr(self, 'total_time', None)
         
         # Check for existing handles
         old_start_handle = self.marker_handles.get('start_handle')
         old_end_handle = self.marker_handles.get('end_handle')
-        print(f"DEBUG: update_plot - Old handles: start_handle={'exists' if old_start_handle is not None else 'none'}, end_handle={'exists' if old_end_handle is not None else 'none'}")
         
         # Save reference to time data
         try:
             if time is not None and len(time) > 0:
-                print(f"DEBUG: update_plot - Time data update: input time_range=[{time[0]}, {time[-1]}], length={len(time)}")
                 new_max_pos = time[-1]
             else:
-                print(f"DEBUG: update_plot - Time data is empty or None")
                 new_max_pos = None
         except TypeError:
-            print(f"DEBUG: TypeError in update_plot - time has no len()")
             new_max_pos = None
             
         self.time_data = time
         
         # Detail all current properties
-        print(f"DEBUG: update_plot - State summary:")
-        print(f"DEBUG:   - Old time_data max={old_max_pos}, New time_data max={new_max_pos}")
-        print(f"DEBUG:   - Marker positions before update: start={old_start_pos}, end={old_end_pos}")
-        print(f"DEBUG:   - Old total_time={old_total_time}")
         
         # Precheck - would end marker need clamping?
         if old_end_pos is not None and new_max_pos is not None and old_end_pos > new_max_pos:
-            print(f"DEBUG: update_plot - ⚠️ End marker ({old_end_pos}) will need clamping to new max ({new_max_pos})")
         
         # Update left channel
-        print(f"DEBUG: update_plot - Updating waveform_left with time_range=[{time[0]}, {time[-1]}]")
         self.waveform_left.setData(time, data_left)
         
         # Set view ranges for left channel
@@ -537,50 +514,39 @@ class PyQtGraphWaveformView(BaseWaveformView):
         # Get marker positions immediately after data update but before clamping
         current_start_pos = self.start_marker.value()
         current_end_pos = self.end_marker.value()
-        print(f"DEBUG: update_plot - Marker positions before clamping: start={current_start_pos}, end={current_end_pos}")
         
         if current_end_pos > new_max_pos:
-            print(f"DEBUG: update_plot - ⚠️ End marker position ({current_end_pos}) exceeds time_data max ({new_max_pos})")
         
         # Check marker handle positions before clamping
         curr_start_handle = self.marker_handles.get('start_handle')
         curr_end_handle = self.marker_handles.get('end_handle')
-        print(f"DEBUG: update_plot - Current handles before clamping: start_handle={'exists' if curr_start_handle is not None else 'none'}, end_handle={'exists' if curr_end_handle is not None else 'none'}")
                 
         # Clamp marker positions to valid range after waveform change
-        print(f"DEBUG: update_plot - About to call _clamp_markers_to_data_bounds()")
         self._clamp_markers_to_data_bounds()
         
         # Get marker positions after clamping
         new_start_pos = self.start_marker.value()
         new_end_pos = self.end_marker.value()
-        print(f"DEBUG: update_plot - Marker positions after clamping: start={new_start_pos}, end={new_end_pos}")
         
         # Verify clamping worked correctly
         if new_max_pos is not None and new_end_pos > new_max_pos:
-            print(f"DEBUG: update_plot - ⚠️⚠️ CLAMPING FAILED: End marker ({new_end_pos}) still exceeds time_data max ({new_max_pos})")
         else:
-            print(f"DEBUG: update_plot - Clamping successful - end marker is within time_data range")
         
         # Check marker handles after clamping
         post_start_handle = self.marker_handles.get('start_handle')
         post_end_handle = self.marker_handles.get('end_handle')
-        print(f"DEBUG: update_plot - Current handles after clamping: start_handle={'exists' if post_start_handle is not None else 'none'}, end_handle={'exists' if post_end_handle is not None else 'none'}")
                 
         # Update marker handles
-        print(f"DEBUG: update_plot - About to update marker handles")
         self._update_marker_handle('start')
         self._update_marker_handle('end')
         
         # Final check on handles
         final_start_handle = self.marker_handles.get('start_handle')
         final_end_handle = self.marker_handles.get('end_handle')
-        print(f"DEBUG: update_plot - Final handles: start_handle={'exists' if final_start_handle is not None else 'none'}, end_handle={'exists' if final_end_handle is not None else 'none'}")
         
         # Print final marker locations
         final_start_pos = self.start_marker.value()
         final_end_pos = self.end_marker.value()
-        print(f"DEBUG: update_plot - Final marker positions: start={final_start_pos}, end={final_end_pos}")
         print(f"==== END WAVEFORM_VIEW UPDATE_PLOT ====\n")
     
     def update_slices(self, slices, total_time=None):
@@ -592,7 +558,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         if total_time is not None:
             old_total_time = getattr(self, 'total_time', None)
             self.total_time = total_time
-            print(f"DEBUG: Total time updated from {old_total_time} to {self.total_time}")
         
         # Save current slices
         self.current_slices = slices
@@ -603,26 +568,20 @@ class PyQtGraphWaveformView(BaseWaveformView):
             if self.time_data is not None and len(self.time_data) > 0:
                 data_max = self.time_data[-1]
         except TypeError:
-            print("DEBUG: TypeError in update_slices when accessing time_data length")
-        print(f"DEBUG: update_slices - Data max={data_max}, Total time={self.total_time}")
-        print(f"DEBUG: update_slices - Marker positions before clamping: start={pre_start_pos}, end={pre_end_pos}")
         
         # Ensure markers are within valid bounds
         try:
             if self.time_data is not None and len(self.time_data) > 0:
                 self._clamp_markers_to_data_bounds()
         except TypeError:
-            print("DEBUG: TypeError in update_slices when checking time_data before clamping")
         
         # Get positions after clamping
         post_start_pos = self.start_marker.value()
         post_end_pos = self.end_marker.value()
-        print(f"DEBUG: update_slices - Marker positions after clamping: start={post_start_pos}, end={post_end_pos}")
         
         # Ensure start and end markers are sufficiently separated
         if abs(post_end_pos - post_start_pos) < 0.1:
             new_end_pos = self.total_time
-            print(f"DEBUG: update_slices - Markers too close together, setting end marker to {new_end_pos}")
             self.set_end_marker(new_end_pos)
         
         # Clear existing slice markers
@@ -646,7 +605,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         # Get final marker positions after all updates
         final_start_pos = self.start_marker.value()
         final_end_pos = self.end_marker.value()
-        print(f"DEBUG: update_slices - Final marker positions: start={final_start_pos}, end={final_end_pos}")
         
         # Update marker handles for both markers
         self._update_marker_handle('start')
@@ -673,28 +631,23 @@ class PyQtGraphWaveformView(BaseWaveformView):
     def set_start_marker(self, position):
         """Set the position of the start marker"""
         # Always print the initial request for debugging
-        print(f"DEBUG: set_start_marker - Called with position={position}")
         
         # Get valid data range from time_data
         if self.time_data is not None and len(self.time_data) > 0:
             data_min = self.time_data[0]
             data_max = self.time_data[-1]
-            print(f"DEBUG: set_start_marker - Current data range: [{data_min}, {data_max}]")
             
             # Ensure position is within valid range
             if position < data_min:
-                print(f"DEBUG: set_start_marker - CLAMPING position from {position} to data_min: {data_min}")
                 position = data_min
                 
             if position > data_max:
                 # Start marker shouldn't be beyond the end of the data
                 new_pos = max(data_min, data_max - 0.01)
-                print(f"DEBUG: set_start_marker - CLAMPING position from {position} to below data_max: {new_pos}")
                 position = new_pos
         else:
             # If we don't have time data, this is probably initialization
             # Just record the intended position and return
-            print(f"DEBUG: set_start_marker - No time data available, setting to {position}")
             # Still verify not negative
             position = max(0.0, position)
             self.start_marker.setValue(position)
@@ -708,7 +661,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
         # Apply snapping if close to the start
         if position < self.snap_threshold:
             position = 0.0
-            print(f"DEBUG: set_start_marker - Snapping to start: {position}")
         
         # Ensure start marker doesn't go beyond end marker
         if self.end_marker is not None:
@@ -716,7 +668,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
             minimum_gap = 0.01  # Minimum 10ms gap between markers
             if position > end_pos - minimum_gap:
                 position = max(0.0, end_pos - minimum_gap)
-                print(f"DEBUG: set_start_marker - Enforcing minimum gap from end marker: {position}")
         
         # Block signals to prevent recursive callbacks
         old_block_state = self.start_marker.blockSignals(True)
@@ -733,7 +684,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
             self.start_marker_right.setValue(position)
             self.start_marker_right.blockSignals(old_block_state)
         
-        print(f"DEBUG: set_start_marker - Final position: {position}")
         
         # Remove old handle if it exists
         if 'start_handle' in self.marker_handles and self.marker_handles['start_handle'] is not None:
@@ -746,23 +696,19 @@ class PyQtGraphWaveformView(BaseWaveformView):
     def set_end_marker(self, position):
         """Set the position of the end marker"""
         # Always print the initial request for debugging
-        print(f"DEBUG: set_end_marker - Called with position={position}")
         
         # Get valid data range from time_data
         if self.time_data is not None and len(self.time_data) > 0:
             data_min = self.time_data[0]
             data_max = self.time_data[-1]
-            print(f"DEBUG: set_end_marker - Current data range: [{data_min}, {data_max}]")
             
             # CRITICAL FIX: ALWAYS enforce data bounds
             # This ensures the end marker is never beyond the available data
             if position > data_max:
-                print(f"DEBUG: set_end_marker - CLAMPING position from {position} to data_max: {data_max}")
                 position = data_max
         else:
             # If we don't have time data, this is probably initialization
             # Just record the intended position and return
-            print(f"DEBUG: set_end_marker - No time data available, setting to {position}")
             # Still verify not negative
             position = max(0.0, position)
             self.end_marker.setValue(position)
@@ -782,7 +728,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
             minimum_gap = 0.01  # Minimum 10ms gap between markers
             if position < start_pos + minimum_gap:
                 position = start_pos + minimum_gap
-                print(f"DEBUG: set_end_marker - Enforcing minimum gap from start marker: {position}")
         
         # Block signals to prevent recursive callbacks
         old_block_state = self.end_marker.blockSignals(True)
@@ -799,7 +744,6 @@ class PyQtGraphWaveformView(BaseWaveformView):
             self.end_marker_right.setValue(position)
             self.end_marker_right.blockSignals(old_block_state)
         
-        print(f"DEBUG: set_end_marker - Final position: {position}")
         
         # Remove old handle if it exists
         if 'end_handle' in self.marker_handles and self.marker_handles['end_handle'] is not None:


### PR DESCRIPTION
Removes all DEBUG-prefixed print statements from waveform_view.py, improving readability and reducing console noise.

Closes #102